### PR TITLE
Default embedded content to null.

### DIFF
--- a/src/X.Bluesky/BlueskyClient.cs
+++ b/src/X.Bluesky/BlueskyClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Frozen;
+using System.Globalization;
 using System.Net.Http.Headers;
 using System.Security.Authentication;
 using System.Text;
@@ -127,7 +128,7 @@ public class BlueskyClient : IBlueskyClient
         }
 
         // Fetch the current time in ISO 8601 format, with "Z" to denote UTC
-        var now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
+        var now = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture);
         var facetBuilder = new FacetBuilder();
 
         var facets = facetBuilder.GetFacets(text);

--- a/src/X.Bluesky/Models/Post.cs
+++ b/src/X.Bluesky/Models/Post.cs
@@ -11,7 +11,7 @@ public record Post
 
     public string CreatedAt { get; set; } = "";
 
-    public Embed Embed { get; set; } = new();
+    public Embed? Embed { get; set; } = null;
 
     public List<string> Langs { get; set; } = new();
 


### PR DESCRIPTION
I've been playing around with this library to write a bot that posts to Blue Sky every so often.  I noticed that whenever I posted something that did not contain a link, the post would show up *very* briefly on the account's timeline and profile.  However, it would disappear after a couple of minutes.  Any other logged in account wouldn't see the post at all.

Stranger still, the client did not report any HTTP errors.  And the posts appear just fine when querying /xrpc/com.atproto.repo.listRecords.  But, I did notice something.

When posting through Blue Sky's web interface, the message JSON looks like this:
```json
{
  "uri": "at://did:plc:wyvn4l5fxqfva2u2shmc7xp6/app.bsky.feed.post/3lbrzykiqer2c",
  "cid": "bafyreibxeidxzc43w5e37yn4vguponi77exzl6eelk4fla5nb464olysom",
  "value": {
    "text": "Testing to see if PDS at at.shendrick.net is working!",
    "$type": "app.bsky.feed.post",
    "langs": [
      "en"
    ],
    "facets": [
      {
        "index": {
          "byteEnd": 41,
          "byteStart": 25
        },
        "features": [
          {
            "uri": "https://at.shendrick.net",
            "$type": "app.bsky.richtext.facet#link"
          }
        ]
      }
    ],
    "createdAt": "2024-11-25T17:23:17.619Z"
  }
}
```
However, when posting with this library, I noticed it adds an "embed" property with a bunch of empty strings when no URL is present.

```json
{
  "uri": "at://did:plc:wyvn4l5fxqfva2u2shmc7xp6/app.bsky.feed.post/3lbw7jox5322i",
  "cid": "bafyreianmrjszogap2subqsc6vquxzuidvwldxyym5wz7efmaq4u2mfo3a",
  "value": {
    "text": "Chirp! The PDS at at.shendrick.net is still online as of: Wednesday, November 27 2024, 4:13AM server time.\nServer's been up for 0 days, 0 hours. #Uptime",
    "$type": "app.bsky.feed.post",
    "embed": {
      "$type": "",
      "external": {
        "uri": "",
        "title": "",
        "description": ""
      }
    },
    "langs": [
      "en",
      "en-US"
    ],
    "facets": [
      {
        "index": {
          "byteEnd": 152,
          "byteStart": 145
        },
        "features": [
          {
            "tag": "Uptime",
            "$type": "app.bsky.richtext.facet#tag"
          }
        ]
      }
    ],
    "createdAt": "2024-11-27T09:13:00Z"
  }
}
```

When I tweaked this library's default embed value to null instead of a bunch of empty strings, posts without any embeds now show up as expected!

---

I also tweaked how the timestamp string was generated.  This issue with the current way is it does not include milliseconds.  I remember reading somewhere (lost the link, sadly) that not including milliseconds may cause posts to not show up in the search windows on Blue Sky.  "o" puts it in the correct format that ATProto requires.

---

Quick disclaimer:  I haven't tested anything else besides my one bot with this change.