### PR TITLE
Add image aspect ratio hints for posts

### DIFF
--- a/src/X.Bluesky/EmbedCards/EmbedImageBuilder.cs
+++ b/src/X.Bluesky/EmbedCards/EmbedImageBuilder.cs
@@ -21,7 +21,7 @@ internal class EmbedImageBuilder : EmbedBuilder
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="images"></param>
     /// <returns></returns>
@@ -37,7 +37,9 @@ internal class EmbedImageBuilder : EmbedBuilder
             {
                 Image = thumb,
                 Alt = image.Alt,
-                // AspectRatio = null
+                AspectRatio = image.Width is not null && image.Height is not null
+                    ? new AspectRatio() { Width = image.Width.Value, Height = image.Height.Value }
+                    : null
             });
         }
 

--- a/src/X.Bluesky/Models/Image.cs
+++ b/src/X.Bluesky/Models/Image.cs
@@ -25,4 +25,18 @@ public record Image
     /// </summary>
     /// <value>A string containing the alt text. Defaults to an empty string.</value>
     public string Alt { get; init; } = "";
+
+    /// <summary>
+    /// Gets or initializes the width of the image in pixels.
+    /// This property is optional and can be null if the width is not specified.
+    /// If both Width and Height are specified, an Aspect Ratio hint will be provided to Bluesky.
+    /// </summary>
+    public int? Width { get; init; } = null;
+
+    /// <summary>
+    /// Gets or initializes the height of the image in pixels.
+    /// This property is optional and can be null if the height is not specified.
+    /// If both Width and Height are specified, an Aspect Ratio hint will be provided to Bluesky.
+    /// </summary>
+    public int? Height { get; init; } = null;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Image embeds now include aspect ratio when width and height are provided, improving display consistency.
  * You can optionally specify image width and height in the image model to enable aspect ratio hints.

* Tests
  * Added tests to verify aspect ratio is included when both dimensions are known and omitted when not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->